### PR TITLE
Update OTP validation and add tax rate models and API routes

### DIFF
--- a/app/Http/Controllers/v1/Company/Settings/ResetPassword/ResetPasswordController.php
+++ b/app/Http/Controllers/v1/Company/Settings/ResetPassword/ResetPasswordController.php
@@ -8,6 +8,7 @@ use App\Http\Requests\Company\Settings\ResetPassword\CurrentPasswordRequest;
 use App\Responser\JsonResponser;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Validator;
 
@@ -46,10 +47,10 @@ class ResetPasswordController extends Controller
     public function confirmOtp(Request $request)
     {
         try {
-            $validator = Validator::make($request, [
-                'otp' => 'required|numeric|digits:5',
+            $validator = Validator::make($request->all(), [
+                'otp' => 'required|numeric|digits:6',
             ]);
-            if ($validator->fail()) {
+            if ($validator->fails()) {
                 throw new BadRequestException($validator->errors()->first(), 422);
             }
 
@@ -102,6 +103,8 @@ class ResetPasswordController extends Controller
             $currentUser->update([
                 'password' => $request->password,
             ]);
+
+            Auth::logout();
 
             return JsonResponser::send(false, 'Password updated successfully', [], Response::HTTP_OK);
         } catch (BadRequestException $e) {

--- a/app/Http/Controllers/v1/Company/Settings/TaxRate/TaxRateController.php
+++ b/app/Http/Controllers/v1/Company/Settings/TaxRate/TaxRateController.php
@@ -1,24 +1,24 @@
 <?php
 
-namespace App\Http\Controllers\v1\Company\Settings\EmailSettings;
+namespace App\Http\Controllers\v1\Company\Settings\TaxRate;
 
 use App\Exceptions\BadRequestException;
 use App\Http\Controllers\Controller;
-use App\Http\Requests\Company\Settings\EmailSettings\CreateEmailSettingsRequest;
+use App\Http\Requests\Company\Settings\TaxRate\CreateTaxRateRequest;
 use App\Http\Requests\Shared\SharedFilterRequest;
 use App\Responser\JsonResponser;
-use App\Services\EmailSettings\EmailSettingsService;
+use App\Services\TaxRate\TaxRateService;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Support\Facades\DB;
 
-class EmailSettingsController extends Controller
+class TaxRateController extends Controller
 {
-    protected EmailSettingsService $emailSettingsService;
+    protected TaxRateService $taxRateService;
 
-    public function __construct(EmailSettingsService $emailSettingsService)
+    public function __construct(TaxRateService $taxRateService)
     {
-        $this->emailSettingsService = $emailSettingsService;
+        $this->taxRateService = $taxRateService;
     }
     /**
      * Display a listing of the resource.
@@ -26,7 +26,7 @@ class EmailSettingsController extends Controller
     public function index(SharedFilterRequest $request)
     {
         try {
-            $records = $this->emailSettingsService->list($request);
+            $records = $this->taxRateService->list($request);
 
             return JsonResponser::send(false, 'Record(s) found successfully', $records, Response::HTTP_OK);
         } catch (BadRequestException $e) {
@@ -39,15 +39,15 @@ class EmailSettingsController extends Controller
     /**
      * Store a newly created resource in storage.
      */
-    public function store(CreateEmailSettingsRequest $request)
+    public function store(CreateTaxRateRequest $request)
     {
         try {
             DB::beginTransaction();
 
-            $record = $this->emailSettingsService->updateOrCreate($request->validated());
+            $record = $this->taxRateService->create($request->validated());
 
             DB::commit();
-            return JsonResponser::send(false, 'Email template created successfully', $record, Response::HTTP_OK);
+            return JsonResponser::send(false, 'Tax rate created successfully', $record, Response::HTTP_OK);
         } catch (BadRequestException $e) {
             DB::rollBack();
             return JsonResponser::send(true, $e->getMessage(), [], $e->getCode());
@@ -63,7 +63,7 @@ class EmailSettingsController extends Controller
     public function show(int $id)
     {
         try {
-            $record = $this->emailSettingsService->view($id);
+            $record = $this->taxRateService->view($id);
 
             return JsonResponser::send(false, 'Record retrieved successfully', $record, Response::HTTP_OK);
         } catch (BadRequestException $e) {
@@ -76,13 +76,13 @@ class EmailSettingsController extends Controller
     /**
      * Update the specified resource in storage.
      */
-    public function update(CreateEmailSettingsRequest $request, int $id)
+    public function update(CreateTaxRateRequest $request, int $id)
     {
         try {
             DB::beginTransaction();
-            $record = $this->emailSettingsService->updateOrCreate([...$request->validated(), "id" => $id]);
+            $record = $this->taxRateService->update($request->validated(), $id);
             DB::commit();
-            return JsonResponser::send(false, 'Email template updated successfully', $record, Response::HTTP_OK);
+            return JsonResponser::send(false, 'Tax rate updated successfully', $record, Response::HTTP_OK);
         } catch (BadRequestException $e) {
             DB::rollBack();
             return JsonResponser::send(true, $e->getMessage(), [], $e->getCode());

--- a/app/Http/Requests/Company/Settings/TaxRate/CreateTaxRateRequest.php
+++ b/app/Http/Requests/Company/Settings/TaxRate/CreateTaxRateRequest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Http\Requests\Company\Settings\TaxRate;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class CreateTaxRateRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        $rules = [
+            'name' => 'required|string|max:225|unique:tax_rates,name',
+            'display_name' => 'required|string|max:24|unique:tax_rates,name',
+            'rate' => 'required|min:0.00',
+            'non_recoverable' => 'nullable',
+            'has_components' => 'nullable',
+            'components' => 'required_if:has_components,true|array',
+            'components.*.name' => 'nullable|string|max:225',
+            'components.*.rate' => 'nullable|min:0.00',
+            'components.*.non_recoverable' => 'nullable',
+            'components.*.compound' => 'nullable',
+        ];
+
+        if ($this->isMethod('PUT') || $this->isMethod('PATCH')) {
+            $rules['name'] = 'required|string|max:225|unique:tax_rates,name,' . $this->route('id');
+            $rules['display_name'] = 'required|string|max:24|unique:tax_rates,name,' . $this->route('id');
+        }
+
+        return $rules;
+    }
+}

--- a/app/Models/TaxRate.php
+++ b/app/Models/TaxRate.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Models;
+
+use App\Models\Scopes\ModelUserScope;
+use App\Traits\Companyable;
+use Illuminate\Database\Eloquent\Attributes\ScopedBy;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+#[ScopedBy([ModelUserScope::class])]
+class TaxRate extends Model
+{
+    use HasFactory, SoftDeletes, Companyable;
+    protected $guarded = ['id'];
+
+    protected $casts = [
+        'non_recoverable' => 'boolean',
+        'has_components' => 'boolean',
+        'is_active' => 'boolean',
+    ];
+
+    public function getAllowedActionsAttribute()
+    {
+        return ['delete', 'toggle'];
+    }
+
+    public function components()
+    {
+        return $this->hasMany(TaxRateComponent::class);
+    }
+}

--- a/app/Models/TaxRateComponent.php
+++ b/app/Models/TaxRateComponent.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Models;
+
+use App\Traits\Companyable;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class TaxRateComponent extends Model
+{
+    use HasFactory, Companyable;
+    protected $guarded = ['id'];
+
+    protected $casts = [
+        'non_recoverable' => 'boolean',
+        'compound' => 'boolean'
+    ];
+}

--- a/app/Services/EmailSettings/EmailSettingsService.php
+++ b/app/Services/EmailSettings/EmailSettingsService.php
@@ -6,6 +6,7 @@ use App\Enums\EmailTemplateModelEnums;
 use App\Exceptions\BadRequestException;
 use App\Models\CompanyEmailTemplate;
 use App\Models\EmailTemplate;
+use Illuminate\Http\Response;
 
 class EmailSettingsService
 {
@@ -55,7 +56,7 @@ class EmailSettingsService
             'emailTemplate:id,name',
         ])->find($id);
         if (!$record) {
-            throw new BadRequestException("Record not found", 404);
+            throw new BadRequestException("Record not found", Response::HTTP_NOT_FOUND);
         }
         return $record;
     }

--- a/app/Services/TaxRate/TaxRateService.php
+++ b/app/Services/TaxRate/TaxRateService.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace App\Services\TaxRate;
+
+use App\Exceptions\BadRequestException;
+use App\Models\TaxRate;
+use Illuminate\Http\Response;
+
+class TaxRateService
+{
+
+    public function list($request)
+    {
+        $records = TaxRate::query()
+            ->select('id', 'name', 'display_name', 'rate', 'is_active', 'created_at')
+            ->withCount(
+                [
+                    'components as account_applicable_count'
+                ]
+            )
+            ->when($request->sort_by, function ($query) use ($request) {
+                if ($request->sort_by == "alphabetically") {
+                    return $query->orderBy('name', 'asc');
+                } else if ($request->sort_by == "date_ascending") {
+                    return $query->orderBy('created_at', 'asc');
+                } else if ($request->sort_by == "date_descending") {
+                    return $query->orderBy('created_at', 'desc');
+                }
+            })
+            ->when($request->status, function ($query) use ($request) {
+                return $query->where('is_active', $request->status);
+            })
+            ->when($request->q, function ($query) use ($request) {
+                return $query->where('name', 'LIKE', '%' . $request->q . '%');
+            })
+            ->when(isset($request->start_date) && $request->start_date && $request->end_date, function ($query) use ($request) {
+                return $query->where('created_at', [$request?->start_date, $request->end_date]);
+            })
+            ->latest();
+
+        if (!$request->paginate) {
+            return $records->get();
+        }
+
+        return $records->paginate($request->limit);
+    }
+
+    public function view($id)
+    {
+        $record = TaxRate::with('components:id,name,rate,non_recoverable,compound,tax_rate_id')->find($id);
+        if (!$record) {
+            throw new BadRequestException('Record not found', Response::HTTP_NOT_FOUND);
+        }
+
+        return $record;
+    }
+
+    public function create($request)
+    {
+        $record = TaxRate::create($request);
+
+        $record->components()->createMany($request['components']);
+
+        return $record;
+    }
+
+    public function update($request, $id)
+    {
+        $record = TaxRate::find($id);
+        $record->update($request);
+        $record->components()->delete();
+        $record->components()->createMany($request['components']);
+        return $record;
+    }
+}

--- a/app/Traits/Companyable.php
+++ b/app/Traits/Companyable.php
@@ -18,8 +18,9 @@ trait Companyable
                 if (
                     !$model->isDirty('company_id') &&
                     Auth::check() &&
-                    method_exists(Auth::user(), 'company') &&
-                    $model->hasAttribute('company_id')
+                    method_exists(Auth::user(), 'company')
+                    // &&
+                    // $model->hasAttribute('company_id')
                 ) {
                     $model->company_id = Auth::user()->company->id ?? null;
                 }

--- a/config/route_model_map.php
+++ b/config/route_model_map.php
@@ -7,6 +7,7 @@ return [
     'credit-notes' => \App\Models\CreditNote::class,
     'suppliers' => \App\Models\Vendor::class,
     'email-settings' => \App\Models\CompanyEmailTemplate::class,
+    'taxes' => \App\Models\TaxRate::class,
     'purchase/vendor-bills' => \App\Models\VendorBill::class,
     'purchase/debit-notes' => \App\Models\DebitNote::class,
     'purchase/invoices' => \App\Models\PurchaseInvoice::class,

--- a/database/migrations/2025_01_12_222236_create_tax_rates_table.php
+++ b/database/migrations/2025_01_12_222236_create_tax_rates_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('tax_rates', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('name');
+            $table->string('display_name');
+            $table->decimal('rate', 4, 2);
+            $table->boolean('non_recoverable')->default(false);
+            $table->boolean('has_components')->default(false);
+            $table->boolean('is_active')->default(true);
+            $table->unsignedBigInteger('company_id');
+            $table->unsignedBigInteger('created_by')->nullable();
+            $table->foreign('created_by')->references('id')->on('users')->onDelete('set null');
+            $table->foreign('company_id')->references('id')->on('companies')->onDelete('cascade');
+            $table->softDeletes();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('tax_rates');
+    }
+};

--- a/database/migrations/2025_01_12_222353_create_tax_rate_components_table.php
+++ b/database/migrations/2025_01_12_222353_create_tax_rate_components_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('tax_rate_components', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('name');
+            $table->decimal('rate', 4, 2);
+            $table->boolean('non_recoverable')->default(false);
+            $table->boolean('compound')->default(false);
+            $table->unsignedBigInteger('tax_rate_id');
+            $table->unsignedBigInteger('company_id');
+            $table->unsignedBigInteger('created_by')->nullable();
+            $table->foreign('created_by')->references('id')->on('users')->onDelete('set null');
+            $table->foreign('tax_rate_id')->references('id')->on('tax_rates')->onDelete('cascade');
+            $table->foreign('company_id')->references('id')->on('companies')->onDelete('cascade');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('tax_rate_components');
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -249,9 +249,13 @@ Route::group([
                     "namespace" => "InvoicingSettings"
                 ], function () {});
                 Route::group([
-                    'prefix' => 'tax',
-                    "namespace" => "Tax"
-                ], function () {});
+                    "namespace" => "TaxRate"
+                ], function () {
+                    Route::apiResource('taxes', 'TaxRateController')
+                        ->missing(function () {
+                            return JsonResponser::send(true, 'Resource not found', null, 404);
+                        });
+                });
             });
 
             Route::group([


### PR DESCRIPTION
Require 6-digit OTP for validation and log out users after password reset. Introduce TaxRate and TaxRateComponent models with migrations and API routes, including validation for tax rate creation.