### PR TITLE
Rename invoice_number to invoiceID for consistency

### DIFF
--- a/app/Services/SharedServices/SharedActionService.php
+++ b/app/Services/SharedServices/SharedActionService.php
@@ -104,7 +104,7 @@ class SharedActionService
     protected function modelSpecificAction(Model $model, Model $newModel)
     {
         if ($newModel instanceof \App\Models\Invoice) {
-            $newModel->invoice_number = $this->generateModelId(
+            $newModel->invoiceID = $this->generateModelId(
                 'App\Models\Invoice',
                 'invoiceID',
                 'Inv',


### PR DESCRIPTION
Update the invoice number property in the modelSpecificAction method to use invoiceID for improved consistency across the codebase.