### PR TITLE
Fix year extraction in DashboardService for empty date filters

### DIFF
--- a/app/Services/SuperAdminDashboardServices/DashboardService.php
+++ b/app/Services/SuperAdminDashboardServices/DashboardService.php
@@ -19,7 +19,7 @@ class DashboardService
         $oneMonthAgo = Carbon::now()->subMonths(1);
         $dateFilter = GeneralHelper::dateFilter($request->date_filter);
         // Extract the year from the start date of $dateFilter
-        $year = Carbon::parse($dateFilter[0])->year;
+        $year = !$dateFilter ? Carbon::now()->year : Carbon::parse($dateFilter[0])->year;
 
         $records = SubscriptionHistory::query()
             ->when($dateFilter, function ($query) use ($dateFilter) {


### PR DESCRIPTION
Ensure the year extraction handles cases where the date filter is empty by defaulting to the current year.