### PR TITLE
Add vendor_bill_due_date to BillsService list query

### DIFF
--- a/app/Services/Bills/BillsService.php
+++ b/app/Services/Bills/BillsService.php
@@ -119,7 +119,8 @@ class BillsService
                 'recurring_end_date',
                 'repeat',
                 'repeat_period',
-                'created_at'
+                'created_at',
+                'vendor_bill_due_date'
             )
             ->with([
                 'vendor:id,vendor_name,referenceID,primary_email',


### PR DESCRIPTION
Improve billing information by including the `vendor_bill_due_date` in the BillsService list query.